### PR TITLE
added build support for gcc < 5 with c++14

### DIFF
--- a/C++/Makefile
+++ b/C++/Makefile
@@ -1,5 +1,11 @@
 # c++ version
+GCC_MAJOR:=$(shell echo $(GCC_VERSION) | cut -d'.' -f1)
+
+ifeq ($(GCC_MAJOR),5)
 CXXFLAGS += -std=c++14
+else
+CXXFLAGS += -std=c++1y
+endif
 
 # warning flags
 CXXFLAGS += -Wall -Wextra -pedantic-errors


### PR DESCRIPTION
I am using ubuntu 14.04 LTS with gcc 4.8 . 
Your Makefile is set to build with support of c++14 and my gcc 4.8 doesn't support this build with the flag of -std=c++14. it support with this flag c++1y . so i created a conditional statement in the MakeFile where if someone has gcc that less than 5 , it will use the flag of c++1y else it will use c++14. 

more practical is to check also the minor version since -std=c++14 is supported from version 5.2 but doing comparison operations in makefile is not flexible as cmake unfortunately. 