### PR TITLE
Add default values for order and to_show_state

### DIFF
--- a/C++/source/sorting/bubble_sort.cpp
+++ b/C++/source/sorting/bubble_sort.cpp
@@ -21,7 +21,7 @@
 
 using namespace std;
 
-void bubble_sort(vector<int>& values, const int order, const bool to_show_state) {
+void bubble_sort(vector<int>& values, const int order = 1, const bool to_show_state = false) {
     bool swapped;
     size_t i, j;
 

--- a/C++/source/sorting/counting_sort.cpp
+++ b/C++/source/sorting/counting_sort.cpp
@@ -21,7 +21,7 @@
 
 using namespace std;
 
-void counting_sort(vector<int>& values, const int order, const bool to_show_state) {
+void counting_sort(vector<int>& values, const int order = 1, const bool to_show_state = false) {
 
     int min_value = values[0];
     int max_value = values[0];

--- a/C++/source/sorting/heap_sort.cpp
+++ b/C++/source/sorting/heap_sort.cpp
@@ -36,7 +36,7 @@ void heapify(vector<int>& heap, int parent, const int last) {
     }
 }
 
-void heap_sort(vector<int>& heap, const int size, const bool to_show_state) {
+void heap_sort(vector<int>& heap, const int size, const bool to_show_state = false) {
     // remove the largest node, replace it with the last node, and re-heapify the heap
 
     if (to_show_state)
@@ -53,7 +53,7 @@ void heap_sort(vector<int>& heap, const int size, const bool to_show_state) {
     }
 }
 
-void make_heap(vector<int>& heap, const int size, const bool to_show_state) {
+void make_heap(vector<int>& heap, const int size, const bool to_show_state = false) {
     /*
         makes an ordered heap by heapifying from highest indexed non-leaf node (curr_node)
         to the top node (index[0])

--- a/C++/source/sorting/insertion_sort.cpp
+++ b/C++/source/sorting/insertion_sort.cpp
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-void insertion_sort(vector<int>& values, const int order, const bool to_show_state) {
+void insertion_sort(vector<int>& values, const int order = 1, const bool to_show_state = false) {
     size_t i, j;
     int currentValue;
 

--- a/C++/source/sorting/merge_sort.cpp
+++ b/C++/source/sorting/merge_sort.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-void merge(vector<int>& values, const size_t start, const size_t end, const int order) {
+void merge(vector<int>& values, const size_t start, const size_t end, const int order = 1) {
     size_t mid = (start + end) / 2;
     size_t index1 = start;
     size_t index2 = mid + 1;
@@ -47,7 +47,7 @@ void merge(vector<int>& values, const size_t start, const size_t end, const int 
        values[s++] = sortedVal;
 }
 
-void merge_sort(vector<int>& values, const size_t start, const size_t end, const int order, const bool toShowState) {
+void merge_sort(vector<int>& values, const size_t start, const size_t end, const int order = 1, const bool toShowState = false) {
     if (start < end) {
         size_t mid = (start + end) / 2;
 

--- a/C++/source/sorting/quick_sort.cpp
+++ b/C++/source/sorting/quick_sort.cpp
@@ -25,7 +25,7 @@
 
 using namespace std;
 
-size_t partition(vector<int>& values, const size_t start, const size_t end, const int order) {
+size_t partition(vector<int>& values, const size_t start, const size_t end, const int order = 1) {
     // choose a random index between start & end
     size_t random_index = start + (rand() % (end - start + 1));
 
@@ -53,7 +53,7 @@ size_t partition(vector<int>& values, const size_t start, const size_t end, cons
     return i-1;     // pivot's index
 }
 
-void quick_sort(vector<int>& values, const int start, const int end, const int order, const bool to_show_state) {
+void quick_sort(vector<int>& values, const int start, const int end, const int order = 1, const bool to_show_state = false) {
     if (start < end) {
         size_t pivot_index = partition(values, start, end, order);
 

--- a/C++/source/sorting/selection_sort.cpp
+++ b/C++/source/sorting/selection_sort.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-void selection_sort(vector<int>& values, const int order, const bool to_show_state) {
+void selection_sort(vector<int>& values, const int order = 1, const bool to_show_state = false) {
     size_t i, j;
 
     // index of either the current minimum or maximum value, depending on the order:

--- a/C++/source/sorting/shell_sort.cpp
+++ b/C++/source/sorting/shell_sort.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-void shell_sort(vector<int>& values, const int order, const bool to_show_state) {
+void shell_sort(vector<int>& values, const int order = 1, const bool to_show_state = false) {
     int n = values.size();
     int temp;
     int i, j;


### PR DESCRIPTION
Adds default values for order and to_show_state in function declarations for each sorting function, with the exception of radix_sort, which takes those arguments by reference. Fixes #136.