### PR TITLE
Replaced assignment of members for constructors with initializer lists

### DIFF
--- a/C++/include/data_structures/binary_search_tree.cpp
+++ b/C++/include/data_structures/binary_search_tree.cpp
@@ -26,8 +26,8 @@ Node* get_node() {
     return newNode;
 }
 
-BinarySearchTree::BinarySearchTree() {
-    root = get_node();
+BinarySearchTree::BinarySearchTree() :
+    root{ get_node() } {
     root->value = INF;
 }
 

--- a/C++/include/data_structures/singly_linked_list.cpp
+++ b/C++/include/data_structures/singly_linked_list.cpp
@@ -27,9 +27,9 @@
 */
 
 template<class T>
-Node<T>::Node(const T& value, Node<T> * const next) {
-    this->value = value;
-    this->next = next;
+Node<T>::Node(const T& value, Node<T> * const next) :
+    value{ value },
+    next{ next } {
 }
 
 
@@ -39,9 +39,9 @@ Node<T>::Node(const T& value, Node<T> * const next) {
 */
 
 template<class T>
-Node<T>::Node(const Node<T> &n) {
-    this->value = n.value;
-    this->next = n.next;
+Node<T>::Node(const Node<T> &n) 
+    value{ n.value }, 
+    next{ n.next } {
 }
 
 
@@ -108,9 +108,10 @@ void set_next(Node<T> * const next) {
 */
 
 template<class T>
-SinglyLinkedList<T>::SinglyLinkedList() {
-    size = 0;
-    head = tail = nullptr;
+SinglyLinkedList<T>::SinglyLinkedList() :
+    size{ 0 },
+    head{ nullptr },
+    tail{ nullptr } {
 }
 
 


### PR DESCRIPTION
<!-- Enter a brief description of the changes you've made in the next line -->

In C++, it is considered good practice to use initializer lists for initializing members. This ensures classes that are const, references, or without default constructors are easily initialized.

<!-- Check the following boxes, if applicable, by replacing the space inside
	"[ ]" with an "x", eg. [x] -->
- [x] Read the [contribution guidelines][contrib-guidelines]
- [x] Added [unit tests][unit-tests] (or unit tests have already been added)

@faheel I am unsure about what style I should use for these lists, so your review would be appreciated! 

<!-- If this PR closes an existing issue, write "Closes #123" in the next line,
        where 123 is the issue number (for example) -->



[contrib-guidelines]: https://github.com/faheel/Algos/blob/master/CONTRIBUTING.md
[unit-tests]: https://github.com/faheel/Algos/blob/master/C%2B%2B/UNIT_TESTS.md
[contents]: https://github.com/faheel/Algos/tree/master/C%2B%2B#contents
