### PR TITLE
Remove "using namespaces std"

### DIFF
--- a/C++/include/sorting/utils.hpp
+++ b/C++/include/sorting/utils.hpp
@@ -10,7 +10,9 @@
 
 #define EXIT_INPUT_SIZE_IS_ZERO 2    // exit code for when input size is 0
 
-using namespace std;
+using std::cin;
+using std::cout;
+using std::string;
 
 /*
     Input utils

--- a/C++/test/algorithm/searching/binary_search.cpp
+++ b/C++/test/algorithm/searching/binary_search.cpp
@@ -1,7 +1,8 @@
 #include "third_party/catch.hpp"
 #include "algorithm/searching/binary_search.hpp"
 
-using namespace std;
+using std::vector;
+using std::string;
 
 TEST_CASE("Base cases", "[searching][binary_search]") {
     REQUIRE(binary_search(0, vector<int>()) == -1);

--- a/C++/test/algorithm/searching/linear_search.cpp
+++ b/C++/test/algorithm/searching/linear_search.cpp
@@ -1,7 +1,8 @@
 #include "third_party/catch.hpp"
 #include "algorithm/searching/linear_search.hpp"
 
-using namespace std;
+using std::vector;
+using std::string;
 
 TEST_CASE("Base cases", "[searching][linear_search]") {
     REQUIRE(linear_search(0, vector<int>()) == -1);

--- a/C++/test/algorithm/searching/ternary_search.cpp
+++ b/C++/test/algorithm/searching/ternary_search.cpp
@@ -3,7 +3,7 @@
 #include "third_party/catch.hpp"
 #include "algorithm/searching/ternary_search.hpp"
 
-using namespace std;
+using std::vector;
 
 /*
     TODO: refactor


### PR DESCRIPTION
<!-- Enter a brief description of the changes you've made in the next line -->
Removes `using namespace std` in the interest of avoiding namespace pollution and following good coding practices.