### PR TITLE
Fix naming from denominator to divisor

### DIFF
--- a/C++/include/algorithm/number_theory/extended_euclidean.hpp
+++ b/C++/include/algorithm/number_theory/extended_euclidean.hpp
@@ -2,7 +2,7 @@
     Extended Euclidean algorithm
     ----------------------------
     Given two non-negative numbers A and B as inputs, find M[0], M[1] such that:
-    greatest_common_denominator(A, B) = M[0]*B + M[1]*B
+    greatest_common_divisor(A, B) = M[0]*B + M[1]*B
 
     Time complexity
     ---------------
@@ -20,12 +20,12 @@ using std::array;
 /*
     extended_euclidean
     ------------------
-    Uses the recurrence relation,
-        greatest_common_denominator(a, b) = greatest_common_denominator(b, a % b),
-    to find coefficients M[0] and M[1] such that
-        greatest_common_denominator(a, b) = (M[0] * a) + (M[1] * b)
+    Uses the recurrence relation:
+        greatest_common_divisor(a, b) = greatest_common_divisor(b, a % b)
+    to find coefficients M[0] and M[1] such that:
+        greatest_common_divisor(a, b) = (M[0] * a) + (M[1] * b)
 
-    Loop invariant: greatest_common_denominator(a, b) is the same at the end of each
+    Loop invariant: greatest_common_divisor(a, b) is the same at the end of each
     iteration a = aM[0] * (original value of a) + aM[1] * (original value of b)
     The above statement holds for b and bM as well.
 


### PR DESCRIPTION
<!-- Enter a brief description of the changes you've made in the next line -->
When committing this file before, I'd erroneously used the term "greatest common denominator". This commit replaces that term with "divisor". 
<!-- Check the following boxes, if applicable, by replacing the space inside
	"[ ]" with an "x", eg. [x] -->
- [x] Read the [contribution guidelines][contrib-guidelines]
- [x] Added [unit tests][unit-tests] (or unit tests have already been added)
- [ ] Updated the [Contents][contents]

<!-- If this PR closes an existing issue, write "Closes #123" in the next line,
        where 123 is the issue number (for example) -->



[contrib-guidelines]: https://github.com/faheel/Algos/blob/master/CONTRIBUTING.md
[unit-tests]: https://github.com/faheel/Algos/blob/master/C%2B%2B/UNIT_TESTS.md
[contents]: https://github.com/faheel/Algos/tree/master/C%2B%2B#contents
