### PR TITLE
Update contribution guidelines and documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,17 +1,29 @@
-# Contributing Guidelines
+# Contribution Guidelines
 
 ## Contents
 
-* [General guidelines](#general-guidelines)
-* [C++ coding guidelines](#c-coding-guidelines)
-* [Pull requests](#pull-requests)
+* [Getting started](#getting-started)
+* [Writing code](#writing-code)
+* [Adding unit tests](#adding-unit-tests)
+* [Opening a pull request](#opening-a-pull-request)
 * [Code of conduct](#code-of-conduct)
 
-## General guidelines
+## Getting started
 
-* When contributing to this repository, please first inform or discuss the
-  change(s) you wish to make via an issue. This helps in letting others know
-  what you're working on.
+* Start by perusing the repository. Take a look at how the algorithms are implemented, how tests
+  are written, and which files go where. 
+
+* Read the contribution guidelines for the language in which you'd like to contribute:
+  * [C++](../C++/CONTRIBUTING.md)
+
+* Before beginning your contribution, [create an issue][issue-guide]. In your issue's 
+  description, please describe the addition or change you wish to make. This helps us guide 
+  your contribution, and it lets others know what you're working on.
+
+## Writing code
+
+* Commit your changes in logical chunks. Use Git's [interactive rebase][rebase-guide]
+  feature to tidy up your commits before making them public.
 
 * For each algorithm, mention its **time complexity** and **space complexity**
   in the _"description comment"_ of its implementation. In case the average-case
@@ -35,13 +47,17 @@
 
 * Before you push your changes to GitHub, make sure that your code compiles and runs without any errors or warnings.
 
-## C++ coding guidelines
+## Writing unit tests
 
-If you are contributing C++ code to this repo, make sure to read the [C++ Coding Guidelines](../C++/CODING_GUIDELINES.md).
+* As stated above, all algorithms and data structures are verified via unit tests.
+  
+* Please make sure that your contribution includes a variety of unit tests and that all of your unit tests pass.
 
-## Pull requests
+* You can find more information about writing unit tests in the contribution guidelines for your particular language. 
 
-Follow the steps below to contribute to the project:
+## Opening a pull request
+
+Follow these steps when you're ready to submit your code:
 
 1. [Fork][fork-guide] the repo, clone your fork, and configure the remotes:
 
@@ -68,23 +84,23 @@ Follow the steps below to contribute to the project:
    git checkout -b <branch-name>
    ```
 
-4. Commit your changes in logical chunks. Use Git's [interactive rebase][rebase-guide]
-   feature to tidy up your commits before making them public.
-
-5. Locally merge (or rebase) the upstream development branch into your branch:
+4. Locally merge (or rebase) the upstream development branch into your branch:
 
    ```bash
    git pull [--rebase] upstream master
    ```
 
-6. Push your branch up to your fork:
+5. Push your branch up to your fork:
 
    ```bash
    git push origin <branch-name>
    ```
 
-7. [Open a pull request][pr-guide] with a clear title and description against the
-   `master` branch.
+6. [Open a pull request][pr-guide] with a clear title and description against the
+   `master` branch. Your pull request should reference the same issue you created 
+   above.
+
+7. Once your pull request has been opened, we'll review it and go from there. :slightly-smiling-face:
 
 ## Code of Conduct
 
@@ -93,3 +109,4 @@ This project has a [Code of Conduct](CODE_OF_CONDUCT.md). Please follow it in al
 [fork-guide]: https://help.github.com/fork-a-repo/
 [rebase-guide]: https://help.github.com/articles/interactive-rebase
 [pr-guide]: https://help.github.com/articles/about-pull-requests/
+[issue-guide]: https://help.github.com/en/articles/about-issues

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -100,7 +100,7 @@ Follow these steps when you're ready to submit your code:
    `master` branch. Your pull request should reference the same issue you created 
    above.
 
-7. Once your pull request has been opened, we'll review it and go from there. :slightly-smiling-face:
+7. Once your pull request has been opened, we'll review it and go from there. :smile:
 
 ## Code of Conduct
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,8 +13,7 @@
 * Start by perusing the repository. Take a look at how the algorithms are implemented, how tests
   are written, and which files go where. 
 
-* Read the contribution guidelines for the language in which you'd like to contribute:
-  * [C++](../C++/CONTRIBUTING.md)
+* Read the [contribution guidelines](../C++/CONTRIBUTING.md).
 
 * Before beginning your contribution, [create an issue][issue-guide]. In your issue's 
   description, please describe the addition or change you wish to make. This helps us guide 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,14 +10,39 @@
 
 ## Getting started
 
-* Start by perusing the repository. Take a look at how the algorithms are implemented, how tests
+* Start by exploring the repository. Take a look at how the algorithms are implemented, how tests
   are written, and which files go where. 
 
-* Read the [contribution guidelines](../C++/CONTRIBUTING.md).
+* Read the [C++ contribution guidelines](../C++/CONTRIBUTING.md).
 
 * Before beginning your contribution, [create an issue][issue-guide]. In your issue's 
   description, please describe the addition or change you wish to make. This helps us guide 
   your contribution, and it lets others know what you're working on.
+
+* [Fork][fork-guide] the repo, clone your fork, and configure the remotes:
+
+   ```bash
+   # Clone your fork of the repo into the current directory
+   git clone https://github.com/<your-username>/Algos.git
+   # Navigate to the newly cloned directory
+   cd Algos
+   # Assign the original repo to a remote called "upstream"
+   git remote add upstream https://github.com/faheel/Algos.git
+   ```
+
+* If you cloned a while ago, get the latest changes from upstream:
+
+   ```bash
+   git checkout master
+   git pull upstream master
+   ```
+
+* Create a new branch (from the `master` branch) to contain your code for a
+   specific algorithm or data structure:
+
+   ```bash
+   git checkout -b <branch-name>
+   ```
 
 ## Writing code
 
@@ -46,60 +71,35 @@
 
 * Before you push your changes to GitHub, make sure that your code compiles and runs without any errors or warnings.
 
-## Writing unit tests
+## Adding unit tests
 
 * As stated above, all algorithms and data structures are verified via unit tests.
   
 * Please make sure that your contribution includes a variety of unit tests and that all of your unit tests pass.
 
-* You can find more information about writing unit tests in the contribution guidelines for your particular language. 
+* You can find more information about writing unit tests [here](../C++/CONTRIBUTING.md). 
 
 ## Opening a pull request
 
 Follow these steps when you're ready to submit your code:
 
-1. [Fork][fork-guide] the repo, clone your fork, and configure the remotes:
-
-   ```bash
-   # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/Algos.git
-   # Navigate to the newly cloned directory
-   cd Algos
-   # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/faheel/Algos.git
-   ```
-
-2. If you cloned a while ago, get the latest changes from upstream:
-
-   ```bash
-   git checkout master
-   git pull upstream master
-   ```
-
-3. Create a new branch (from the `master` branch) to contain your code for a
-   specific algorithm or data structure:
-
-   ```bash
-   git checkout -b <branch-name>
-   ```
-
-4. Locally merge (or rebase) the upstream development branch into your branch:
+1. Locally merge (or rebase) the upstream development branch into your branch:
 
    ```bash
    git pull [--rebase] upstream master
    ```
 
-5. Push your branch up to your fork:
+1. Push your branch up to your fork:
 
    ```bash
    git push origin <branch-name>
    ```
 
-6. [Open a pull request][pr-guide] with a clear title and description against the
+1. [Open a pull request][pr-guide] with a clear title and description against the
    `master` branch. Your pull request should reference the same issue you created 
    above.
 
-7. Once your pull request has been opened, we'll review it and go from there. :smile:
+1. Once your pull request has been opened, we'll review it and go from there. :smile:
 
 ## Code of Conduct
 

--- a/C++/CONTRIBUTING.md
+++ b/C++/CONTRIBUTING.md
@@ -10,7 +10,7 @@ so, please read the [general contribution guidelines][contrib-guide].
 
 ## Coding guidelines
 
-* This project adheres to the [C++ Coding Guidelines](../C++/CODING_GUIDELINES.md). Please read (and follow!) them.
+This project adheres to the [C++ Coding Guidelines](../C++/CODING_GUIDELINES.md). Please read (and follow!) them.
 
 ## Unit tests
 
@@ -22,8 +22,8 @@ the implementation and the unit tests.
 
 1. Under `test`, locate (or create, if it doesn't exist)
    the directory having the same relative path from `test` as from `include`.
-   For example, if you've created a header file in `include/algorithm/searching/some_dir/`,
-   locate or create the directory `test/algorithm/searching/some_dir`.
+   For example, if you've created a header file in `include/algorithm/searching`,
+   locate (or create) the directory `test/algorithm/searching`.
 
 1. Create a file with the same name as the corresponding header file for which
    you are writing tests, except that the extension should be `.cpp`.
@@ -40,7 +40,7 @@ the implementation and the unit tests.
     `include/algorithm/searching/linear_search.hpp`, you can write:
 
     ```cpp
-    #include "algorithms/searching/linear_search.hpp"
+    #include "algorithm/searching/linear_search.hpp"
     ```
 
 1. After these lines you can add your test cases. For details regarding how to
@@ -50,13 +50,13 @@ the implementation and the unit tests.
    tests are written.
 
 1. Add an entry for your unit test in `CMakeLists.txt`. For example, if your
-   unit test is `test/algorithm/some_dir/some_test.cpp`, add the following
+   unit test is `test/algorithm/searching/linear_search.cpp`, add the following
    entry for it:
 
    ```cmake
-   add_executable(some_test
-           test/algorithm/some_dir/some_test.cpp)
-   target_link_libraries(some_test test_runner)
+    add_executable(linear_search
+           test/algorithm/searching/linear_search.cpp)
+    target_link_libraries(linear_search test_runner)
    ```
 
 That's it! Now you can compile the test using **`make test`** from the

--- a/C++/CONTRIBUTING.md
+++ b/C++/CONTRIBUTING.md
@@ -1,9 +1,29 @@
-# Adding unit tests for C++ code
+# C++ Contribution Guidelines
 
-1. Under the [`test` directory](test), locate (or create, if it doesn't exist)
+This page describes the specifics of implementing algorithms and data structures in C++. If you have not already done
+so, please read the [general contribution guidelines][contrib-guide].
+
+## Contents
+
+* [Coding guidelines](#coding-guidelines)
+* [Unit tests](#unit-tests)
+
+## Coding guidelines
+
+* This project adheres to the [C++ Coding Guidelines](../C++/CODING_GUIDELINES.md). Please read (and follow!) them.
+
+## Unit tests
+
+Algorithms and data structures are implemented as header files (.hpp) in the [`include` directory](include) and then verified via
+unit test files (.cpp) in the [`test` directory](test). If you're adding an algorithm or data structure, you'll write both
+the implementation and the unit tests. 
+
+#### Adding unit tests
+
+1. Under [`test`](test), locate (or create, if it doesn't exist)
    the directory having the same relative path from `test` as from `include`.
-   **Eg.** if you've created a header file in `include/algorithms/some_dir/`,
-   locate or create the directory `test/algorithms/some_dir`.
+   For example, if you've created a header file in `include/algorithm/searching/some_dir/`,
+   locate or create the directory `test/algorithm/searching/some_dir`.
 
 1. Create a file with the same name as the corresponding header file for which
    you are writing tests, except that the extension should be `.cpp`.
@@ -17,7 +37,7 @@
 
     The path to the header file is relative from the `include` directory. So,
     for instance, if you need to include the header file
-    `include/algorithms/searching/linear_search.hpp`, you can write:
+    `include/algorithm/searching/linear_search.hpp`, you can write:
 
     ```cpp
     #include "algorithms/searching/linear_search.hpp"
@@ -39,10 +59,11 @@
    target_link_libraries(some_test test_runner)
    ```
 
-**That's it!** Now you can compile the test using **`make test`** from the
+That's it! Now you can compile the test using **`make test`** from the
 `C++` directory, which will also run all of the tests for you. In order to run
 only a specific test and see its results, run it manually from the `bin` directory.
 
+[contrib-guide]: .github/CONTRIBUTING.md
 [catch]: https://github.com/catchorg/Catch2
 [catch-tutorial]: https://github.com/catchorg/Catch2/blob/master/docs/tutorial.md#writing-tests
 [unit-tests]: https://github.com/faheel/Algos/tree/master/C%2B%2B/test

--- a/C++/CONTRIBUTING.md
+++ b/C++/CONTRIBUTING.md
@@ -20,7 +20,7 @@ the implementation and the unit tests.
 
 #### Adding unit tests
 
-1. Under [`test`](test), locate (or create, if it doesn't exist)
+1. Under `test`, locate (or create, if it doesn't exist)
    the directory having the same relative path from `test` as from `include`.
    For example, if you've created a header file in `include/algorithm/searching/some_dir/`,
    locate or create the directory `test/algorithm/searching/some_dir`.

--- a/C++/README.md
+++ b/C++/README.md
@@ -2,7 +2,7 @@
 
 [![Travis status][travis-shield]][travis-link]
 
-Implementation and verification of well-known (and some rare) algorithms, in C++.
+Implementing well-known (and some rare) **algorithms and data structures in C++**, while following **good software engineering practices** such as writing well-documented code, adhering to code guidelines, writing unit tests, reviewing each other's code, and ultimately learning to be better software developers.
 
 ## Contents
 

--- a/C++/README.md
+++ b/C++/README.md
@@ -2,7 +2,7 @@
 
 [![Travis status][travis-shield]][travis-link]
 
-Implementation of well-known (and some rare) algorithms, in C++.
+Implementation and verification of well-known (and some rare) algorithms, in C++.
 
 ## Contents
 
@@ -66,19 +66,25 @@ To compile the source files, run **`make all`**. Doing so will:
 
 The sub-directories will be the same as they are under `source`.
 
-To compile and run the tests, run **`make test`**. This will compile all the tests (in the same way as described above) and will run them, displaying the results. Note that the test binaries will have `.test` at the end of their name.
+To compile and run the tests, run **`make test`**. This will compile all the tests (in the same way as described above) 
+and will run them, displaying the results. Note that the test binaries will have `.test` at the end of their name.
 
-To remove all of the files created during compilation, run **`make clean`**. You need not do this every time you make some changes to a file and want to recompile it. Just run **`make all`**, and it will re-compile just those files whose contents have changed.
+To remove all of the files created during compilation, run **`make clean`**. You need not do this every time you make 
+some changes to a file and want to recompile it. Just run **`make all`**, and it will re-compile just those files whose 
+contents have changed.
 
-To know what happens in the background when **`make`** runs, you may read the [Makefile](Makefile). For more information on **`make`**, read the [GNU make Manual](https://www.gnu.org/software/make/manual/make.html).
+To know what happens in the background when **`make`** runs, you may read the [Makefile](Makefile). For more information 
+on **`make`**, read the [GNU make Manual](https://www.gnu.org/software/make/manual/make.html).
 
-## Unit tests
+## Contributing
 
-If you would like to (and you should) add unit tests for the code you are contributing, or for some of the existing code, read about [Adding unit tests for C++ code](UNIT_TESTS.md).
+If you want to contribute an algorithm or data structure in C++, please have a look at the following guidelines: 
+* [General Contribution Guidelines](CONTRIBUTING.md)
+* [C++ Contribution Guidelines](../CONTRIBUTING.md) 
+* [C++ Coding Guidelines](CODING_GUIDELINES.md)
 
-## C++ Coding Guidelines
-
-If you want to contribute an algorithm or data structure in C++, make sure to read the [C++ Coding Guidelines](CODING_GUIDELINES.md) apart from the general [Contributing Guidelines](../CONTRIBUTING.md). This will help in ensuring that your code conforms to the style followed in this project.
+Following the guidelines laid out in these documents will ensure that your code conforms to the standards and style 
+of the project.
 
 [travis-shield]: https://img.shields.io/travis/faheel/Algos.svg?style=for-the-badge
 [travis-link]: https://travis-ci.org/faheel/Algos

--- a/C++/README.md
+++ b/C++/README.md
@@ -79,8 +79,8 @@ on **`make`**, read the [GNU make Manual](https://www.gnu.org/software/make/manu
 ## Contributing
 
 If you want to contribute an algorithm or data structure in C++, please have a look at the following guidelines: 
-* [General Contribution Guidelines](CONTRIBUTING.md)
-* [C++ Contribution Guidelines](../CONTRIBUTING.md) 
+* [General Contribution Guidelines](../.github/CONTRIBUTING.md)
+* [C++ Contribution Guidelines](CONTRIBUTING.md) 
 * [C++ Coding Guidelines](CODING_GUIDELINES.md)
 
 Following the guidelines laid out in these documents will ensure that your code conforms to the standards and style 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implementation and verification of well-known (and some rare) algorithms and dat
 1. Guide potential contributors on version control, unit testing, and algorithms.
 1. Add at least one algorithm every week.
 
-## Get involved
+## Get involved!
 
 There are a few ways to get involved.
 
@@ -31,7 +31,7 @@ guidelines][contrib-guide], so be sure to check them out.
 
 #### Just want to suggest a new algorithm or report a bug?
 
-[Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
+- [Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
 handle it from there. :smile:
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implementation and verification of well-known (and some rare) algorithms and dat
 1. Guide potential contributors on version control, unit testing, and algorithms.
 1. Add at least one algorithm every week.
 
-## Get involved!
+## How to get involved
 
 There are a few ways to get involved.
 

--- a/README.md
+++ b/README.md
@@ -3,36 +3,40 @@
 [![Travis status][travis-shield]][travis-link]
 [![Gitter](https://img.shields.io/gitter/room/Algos/Algos.svg?style=for-the-badge)](https://gitter.im/Algos-f)
 
-Implementation of well-known (and some rare) algorithms, mostly in C++.
+Implementation and verification of well-known (and some rare) algorithms and data structures.
 
 ## Contents
 
-For algorithms and data structures in C++, check out the list [here](C++).
+* [C++](C++)
 
-## My goal
+## Goals
 
-> Add at least 1 algorithm to the repo every week.
+1. Guide potential contributors on version control, unit testing, and algorithms.
+1. Add at least one algorithm every week.
 
-### Want to contribute to open-source and help me achieve the goal?
+## Get involved
 
-1. Read the [**contribution guidelines**][contrib-guide]
-2. **Fork** the repo
-3. Create a **branch** and **add your implementation** of an algorithm (or
-   data structure) that is not already in the repo
-4. Add **unit tests** for the code you've added
-5. Submit a **pull request**
+There are a few ways to get involved.
+
+##### Want to contribute to open-source and get involved with the project?
+
+1. **Read** the [contribution guidelines][contrib-guide]
+1. **Fork** the repo
+1. **Create an issue** describing what you'd like to add, or **claim an issue** that's [up for grabs][up-for-grabs]
+1. Create a **branch** and **add your code**
+1. Submit a **pull request** and reference the issue it closes
 
 You can find more details regarding the steps above in the [contribution
 guidelines][contrib-guide], so be sure to check them out.
 
-### Want to suggest some algorithms to add?
+##### Just want to suggest a new algorithm or report a bug?
 
-Just [create a new issue](https://github.com/faheel/Algos/issues/new) and I'll
-handle it from there :smile:
+[Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
+handle it from there. :smile:
 
 ## Maintainers
 
-This repo is being actively maintained by @alxmjo, and inactively by @faheel.
+This repo is actively maintained by [@alxmjo](https://github.com/alxmjo), and inactively by [@faheel](https://github.com/faheel).
 
 ## License
 
@@ -41,3 +45,4 @@ This project is licensed under the terms of the [MIT license](LICENSE.md).
 [travis-shield]: https://img.shields.io/travis/faheel/Algos.svg?style=for-the-badge
 [travis-link]: https://travis-ci.org/faheel/Algos
 [contrib-guide]: .github/CONTRIBUTING.md
+[up-for-grabs]: https://github.com/faheel/Algos/labels/Up%20for%20grabs

--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 [![Travis status][travis-shield]][travis-link]
 [![Gitter](https://img.shields.io/gitter/room/Algos/Algos.svg?style=for-the-badge)](https://gitter.im/Algos-f)
 
-Implementation and verification of well-known (and some rare) algorithms and data structures.
-
-## Contents
-
-* [C++](C++)
+Implementation and verification of well-known (and some rare) algorithms and data structures, in C++.
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ There are a few ways to get involved.
 You can find more details regarding the steps above in the [contribution
 guidelines][contrib-guide], so be sure to check them out.
 
-#### Just want to suggest a new algorithm or report a bug?
+#### Just want to suggest a new algorithm or report a bug? 
 
-- [Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
+[Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
 handle it from there. :smile:
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis status][travis-shield]][travis-link]
 [![Gitter](https://img.shields.io/gitter/room/Algos/Algos.svg?style=for-the-badge)](https://gitter.im/Algos-f)
 
-Implementation and verification of well-known (and some rare) algorithms and data structures, in C++.
+Implementing well-known (and some rare) **algorithms and data structures**, while following **good software engineering practices** such as writing well-documented code, adhering to code guidelines, writing unit tests, reviewing each other's code, and ultimately learning to be better software developers.
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Implementation and verification of well-known (and some rare) algorithms and dat
 
 There are a few ways to get involved.
 
-##### Want to contribute to open-source and get involved with the project?
+#### Want to contribute to open-source and get involved with the project?
 
 1. **Read** the [contribution guidelines][contrib-guide]
 1. **Fork** the repo
@@ -29,7 +29,7 @@ There are a few ways to get involved.
 You can find more details regarding the steps above in the [contribution
 guidelines][contrib-guide], so be sure to check them out.
 
-##### Just want to suggest a new algorithm or report a bug?
+#### Just want to suggest a new algorithm or report a bug?
 
 [Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
 handle it from there. :smile:


### PR DESCRIPTION
<!-- Enter a brief description of the changes you've made in the next line -->

There are a few ideas wrapped up in this PR:
- Modify goals of project (add education as explicit goal)
- Modify general contribution guidelines to be language-agnostic
- Create language-specific contribution guidelines
- Roll unit test guidelines into language contribution guidelines

I know I'm going out on a limb by suggesting modification to the goals (since they were @faheel's goals to begin with), but since there's been so much interest from relative newbies (myself included!) this seems like a great direction to move in (and one we'd been implicitly moving in for a while).

As for breaking out the guidelines into general and language-specific documents, this fits with @faheel's mention of adding another language (Go, I believe), interest from others, and interest from myself (I think we really need some algorithms in Assembly...not really).

For the unit tests, I just felt like this made sense to include within the contribution guidelines. The coding guidelines were a much larger document, however, and I didn't want the contribution guidelines to be so long that no one would read them.

This is submitted as very much a work in progress.

Closes #258 

[contrib-guidelines]: https://github.com/faheel/Algos/blob/master/CONTRIBUTING.md
[unit-tests]: https://github.com/faheel/Algos/blob/master/C%2B%2B/UNIT_TESTS.md
[contents]: https://github.com/faheel/Algos/tree/master/C%2B%2B#contents