### PR TITLE
Overloading  ternary search to accept a function and an interval as parameters

### DIFF
--- a/C++/include/algorithm/searching/ternary_search.hpp
+++ b/C++/include/algorithm/searching/ternary_search.hpp
@@ -88,11 +88,21 @@ template <typename F, typename T,
           std::enable_if_t<std::is_integral<T>::value, int> = 0>
 T ternary_search(F f, T start, T end, const Pattern& pattern) {
     T start_third, end_third;
+
+    // Shrink the search range by a third of the size at every iteration until
+    // the distance between start and end is below 3.
     while ((end - start) > 2) {
+        // Compute the points at one third and two thirds of the distance from start and end
         start_third = start + (end - start) / 3;
         end_third = end - (end - start) / 3;
 
         const bool end_bigger =  f(start_third) < f(end_third);
+        // If the function is ascending then descending then if f(end_third) is bigger then f(start_third)
+        // that means that the maximum of the function cannot be between start and start_third and thus
+        // the search range can be reduced to start_third and end; if f(start_third) is bigger then the
+        // that the maximum of the function cannot be between end_third and end and thus
+        // the search range can be reduced to start and end_third
+        // The behavior is reversed for a function descending and then ascending
         if ((ASCEND_THEN_DESCEND == pattern && end_bigger)
             || (DESCEND_THEN_ASCEND == pattern && !end_bigger)) {
             start = start_third;
@@ -102,9 +112,12 @@ T ternary_search(F f, T start, T end, const Pattern& pattern) {
         }
     }
 
+    // If start is equal to end, the extremum index was found
     if (start == end) {
         return start;
     }
+
+    // Iterate through the shrank search range to find the extrema and their indexes
     auto max_value = f(end);
     auto min_value = f(end);
     T max_x = end;
@@ -120,6 +133,7 @@ T ternary_search(F f, T start, T end, const Pattern& pattern) {
             min_x = i;
         }
     }
+    // If the function is ascending then descending, the maximum index should be returned otherwise the minimum index
     return pattern == ASCEND_THEN_DESCEND ? max_x : min_x;
 }
 
@@ -137,11 +151,21 @@ template <typename F, typename T,
 T ternary_search(F f, T start, T end, const Pattern& pattern, const T abs_precision) {
     T start_third, end_third;
     bool changed = true;
+    // Shrink the search range by a third of the size at every iteration until
+    // the distance between start and end is below the desired_absolute precision
+    // or the search range does not change anymore
     while (((end - start) > abs_precision) && changed) {
+        // Compute the points at one third and two thirds of the distance from start and end
         start_third = start + (end - start) / 3.0;
         end_third = end - (end - start) / 3.0;
 
         const bool end_bigger =  f(start_third) < f(end_third);
+        // If the function is ascending then descending then if f(end_third) is bigger then f(start_third)
+        // that means that the maximum of the function cannot be between start and start_third and thus
+        // the search range can be reduced to start_third and end; if f(start_third) is bigger then the
+        // that the maximum of the function cannot be between end_third and end and thus
+        // the search range can be reduced to start and end_third
+        // The behavior is reversed for a function descending and then ascending
         if ((ASCEND_THEN_DESCEND == pattern && end_bigger)
             || (DESCEND_THEN_ASCEND == pattern && !end_bigger)) {
             changed = (start != start_third);
@@ -153,6 +177,7 @@ T ternary_search(F f, T start, T end, const Pattern& pattern, const T abs_precis
         }
     }
 
+    // returns the midpoint of the extrema index result range
     return (start + end) / 2.0;
 }
 

--- a/C++/include/algorithm/searching/ternary_search.hpp
+++ b/C++/include/algorithm/searching/ternary_search.hpp
@@ -128,7 +128,7 @@ T ternary_search(F f, T start, T end, const Pattern& pattern) {
     --------------------------------------------------------
     If the given function f first ascends and then descends (pattern == ASCEND_THEN_DESCEND)
     , this function finds the value x for which f(x) is maximum on the interval [start, end]
-    with a tolerance of abs_precision. Otherwise, this function finds the integral value x
+    with a tolerance of abs_precision. Otherwise, this function finds the value x
     for which f(x) is minimum on the interval [start, end] with a tolerance of abs_precision.
 */
 

--- a/C++/include/algorithm/searching/ternary_search.hpp
+++ b/C++/include/algorithm/searching/ternary_search.hpp
@@ -128,25 +128,27 @@ T ternary_search(F f, T start, T end, const Pattern& pattern) {
     --------------------------------------------------------
     If the given function f first ascends and then descends (pattern == ASCEND_THEN_DESCEND)
     , this function finds the value x for which f(x) is maximum on the interval [start, end]
-    with a tolerance of abs_precision. Otherwise, this function finds the value x
-    for which f(x) is minimum on the interval [start, end] with a tolerance of abs_precision.
+    with a tolerance of abs_precision (or when the algorithm stops converging). 
+    Otherwise, this function finds the value x for which f(x) is minimum on the interval [start, end].
 */
 
 template <typename F, typename T,
           std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
 T ternary_search(F f, T start, T end, const Pattern& pattern, const T abs_precision) {
     T start_third, end_third;
-
-    while ((end - start) > abs_precision) {
+    bool changed = true;
+    while (((end - start) > abs_precision) && changed) {
         start_third = start + (end - start) / 3.0;
         end_third = end - (end - start) / 3.0;
 
         const bool end_bigger =  f(start_third) < f(end_third);
         if ((ASCEND_THEN_DESCEND == pattern && end_bigger)
             || (DESCEND_THEN_ASCEND == pattern && !end_bigger)) {
+            changed = (start != start_third);
             start = start_third;
         }
         else {
+            changed = (end != end_third);
             end = end_third;
         }
     }

--- a/C++/include/algorithm/searching/ternary_search.hpp
+++ b/C++/include/algorithm/searching/ternary_search.hpp
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <vector>
+#include <functional>
 
 enum Pattern {
     ASCEND_THEN_DESCEND,
@@ -73,6 +74,84 @@ size_t ternary_search(const std::vector<T>& values, const Pattern& pattern) {
     }
 
     return pattern == ASCEND_THEN_DESCEND ? max_index : min_index;
+}
+
+/*
+    ternary_search given a function and an integral interval
+    --------------------------------------------------------
+    If the given function f first ascends and then descends (pattern == ASCEND_THEN_DESCEND)
+    , this function finds the integral value x for which f(x) is maximum on the interval [start, end].
+    Otherwise, this function finds the integral value x for which f(x) is minimum on the interval [start, end].
+*/
+
+template <typename F, typename T,
+          std::enable_if_t<std::is_integral<T>::value, int> = 0>
+T ternary_search(F f, T start, T end, const Pattern& pattern) {
+    T start_third, end_third;
+    while ((end - start) > 2) {
+        start_third = start + (end - start) / 3;
+        end_third = end - (end - start) / 3;
+
+        const bool end_bigger =  f(start_third) < f(end_third);
+        if ((ASCEND_THEN_DESCEND == pattern && end_bigger)
+            || (DESCEND_THEN_ASCEND == pattern && !end_bigger)) {
+            start = start_third;
+        }
+        else {
+            end = end_third;
+        }
+    }
+
+    if (start == end) {
+        return start;
+    }
+    auto max_value = f(end);
+    auto min_value = f(end);
+    T max_x = end;
+    T min_x = end;
+    for (T i = start; i < end ; ++i) {
+        auto f_value = f(i);
+        if (f_value > max_value) {
+            max_value = f_value;
+            max_x = i;
+        }
+        else if (min_value > f_value) {
+            min_value = f_value;
+            min_x = i;
+        }
+    }
+    return pattern == ASCEND_THEN_DESCEND ? max_x : min_x;
+}
+
+/*
+    ternary_search given a function and an floating point interval
+    --------------------------------------------------------
+    If the given function f first ascends and then descends (pattern == ASCEND_THEN_DESCEND)
+    , this function finds the value x for which f(x) is maximum on the interval [start, end]
+    with a tolerance of abs_precision. Otherwise, this function finds the integral value x
+    for which f(x) is minimum on the interval [start, end] with a tolerance of abs_precision.
+*/
+
+template <typename F, typename T,
+          std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+T ternary_search(F f, T start, T end, const Pattern& pattern, const T abs_precision) {
+    T start_third, end_third;
+
+    while ((end - start) > abs_precision) {
+        start_third = start + (end - start) / 3.0;
+        end_third = end - (end - start) / 3.0;
+
+        const bool end_bigger =  f(start_third) < f(end_third);
+        if ((ASCEND_THEN_DESCEND == pattern && end_bigger)
+            || (DESCEND_THEN_ASCEND == pattern && !end_bigger)) {
+            start = start_third;
+        }
+        else {
+            end = end_third;
+        }
+    }
+
+    return (start + end) / 2.0;
 }
 
 #endif // TERNARY_SEARCH_HPP

--- a/C++/test/algorithm/searching/ternary_search.cpp
+++ b/C++/test/algorithm/searching/ternary_search.cpp
@@ -1,5 +1,4 @@
-#include <algorithm>
-#include <math.h>
+#include <cmath>
 
 #include "third_party/catch.hpp"
 #include "algorithm/searching/ternary_search.hpp"
@@ -88,21 +87,25 @@ TEST_CASE("Base cases", "[searching][ternary_search]") {
     REQUIRE(ternary_search(vector<int>({4, 5}), ASCEND_THEN_DESCEND) == 1);
     REQUIRE(ternary_search(vector<int>({4, 5}), DESCEND_THEN_ASCEND) == 0);
 
+    // Testing ternary search for integer range and ascending then descending functions
     REQUIRE(ternary_search(&ascending_descending_func_int, 2, 2, ASCEND_THEN_DESCEND) == 2);
     REQUIRE(ternary_search(&ascending_descending_func_int, 2, 3, ASCEND_THEN_DESCEND) == 2);
     REQUIRE(ternary_search([](int x){return -(x - 2) * (x - 2);}, 1, 2, ASCEND_THEN_DESCEND) == 2);
     REQUIRE(ternary_search([](int x){return -(x - 2) * (x - 2);}, -4, -3, ASCEND_THEN_DESCEND) == -3);
 
+    // Testing ternary search for integer range and descending then ascending functions
     REQUIRE(ternary_search(&descending_ascending_func_int, 5, 5, DESCEND_THEN_ASCEND) == 5);
     REQUIRE(ternary_search(&descending_ascending_func_int, 5, 6, DESCEND_THEN_ASCEND) == 5);
     REQUIRE(ternary_search([](int x){return (x - 5) * (x - 5) * (x - 5) * (x - 5);}, 4, 5, DESCEND_THEN_ASCEND) == 5);
     REQUIRE(ternary_search([](int x){return (x - 5) * (x - 5) * (x - 5) * (x - 5);}, 12, 13, DESCEND_THEN_ASCEND) == 12);
 
+    // Testing ternary search for float range and ascending then descending functions
     REQUIRE(ternary_search(&ascending_descending_func_float, 9.0, 9.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(9.0));
     REQUIRE(ternary_search(&ascending_descending_func_float, 8.0, 9.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(9.0));
     REQUIRE(ternary_search([](float x){return -(x - 9.0f) * (x - 9.0f);}, 9.0, 10.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(9.0));
     REQUIRE(ternary_search([](float x){return -(x - 9.0f) * (x - 9.0f);}, -4.0, -3.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(-3.0));
 
+    // Testing ternary search for float range and descending then ascending functions
     REQUIRE(ternary_search(&descending_ascending_func_float, 0.5, 0.5, DESCEND_THEN_ASCEND, 10e-9) == Approx(0.5));
     REQUIRE(ternary_search(&descending_ascending_func_float, 0.4, 0.5, DESCEND_THEN_ASCEND, 10e-9) == Approx(0.5));
     REQUIRE(ternary_search([](float x){return (x - 0.5f) * (x - 0.5f) * (x - 0.5f) * (x - 0.5f);}, 0.5, 0.6, DESCEND_THEN_ASCEND, 10e-9) == Approx(0.5));

--- a/C++/test/algorithm/searching/ternary_search.cpp
+++ b/C++/test/algorithm/searching/ternary_search.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <math.h>
 
 #include "third_party/catch.hpp"
 #include "algorithm/searching/ternary_search.hpp"
@@ -127,7 +128,10 @@ TEST_CASE("Normal cases", "[searching][ternary_search]") {
     REQUIRE(ternary_search([](int x){return -(x - 150) * (x - 150);}, 0, 400, ASCEND_THEN_DESCEND) == 150);
     REQUIRE(ternary_search([](float x){return (x + 351) * (x + 351);}, -1250, 5689, DESCEND_THEN_ASCEND) == -351);
 
-    REQUIRE(ternary_search(&sin, 0.0, M_PI, ASCEND_THEN_DESCEND, 10e-9) == Approx(M_PI_2));
-    REQUIRE(ternary_search(&cos, 0.0, 2.0 * M_PI, DESCEND_THEN_ASCEND, 10e-9) == Approx(M_PI));
-    REQUIRE(ternary_search(&tan, -M_PI/4, M_PI/4, ASCEND_THEN_DESCEND, 10e-9) == Approx(M_PI/4));
+    REQUIRE(ternary_search([](double d){return sin(d);}, 0.0, M_PI, ASCEND_THEN_DESCEND, 10e-9) == Approx(M_PI_2));
+    REQUIRE(ternary_search([](double d){return cos(d);}, 0.0, 2.0 * M_PI, DESCEND_THEN_ASCEND, 10e-9) == Approx(M_PI));
+    REQUIRE(ternary_search([](double d){return tan(d);}, -M_PI/4, M_PI/4, ASCEND_THEN_DESCEND, 10e-9) == Approx(M_PI/4));
+
+    REQUIRE(ternary_search([](float d){return (d <= -2.1f) ? d * 5.5f :-16.2f - d * 2.5f;}, -4509.0f, 240.878f, ASCEND_THEN_DESCEND, 10e-9f) == Approx(-2.1f));
+    REQUIRE(ternary_search([](float d){return (d <= 3.2f) ? - d * 3.0f :-13.44f + d * 1.2f;}, -25.2f, 240.3f, DESCEND_THEN_ASCEND, 10e-9f) == Approx(3.2f));
 }

--- a/C++/test/algorithm/searching/ternary_search.cpp
+++ b/C++/test/algorithm/searching/ternary_search.cpp
@@ -39,9 +39,10 @@ vector<int> nextRandUnimodal(int size, const bool pattern) {
 }
 
 size_t get_expected_index(const vector<int>& values, const bool pattern) {
-    int val, expected_index;
+    int val;
+    size_t expected_index = 0;
     if (!pattern) {
-        val = -1e9;
+        val = std::numeric_limits<int>::min();
         for (size_t i = 0; i < values.size(); i++) {
             if (val < values[i]){
                 val = values[i];
@@ -49,7 +50,7 @@ size_t get_expected_index(const vector<int>& values, const bool pattern) {
             }
         }
     } else {
-        val = 1e9;
+        val = std::numeric_limits<int>::max();
         for (size_t i = 0; i < values.size(); i++) {
             if (val > values[i]){
                 val = values[i];
@@ -60,6 +61,23 @@ size_t get_expected_index(const vector<int>& values, const bool pattern) {
     return expected_index;
 }
 
+
+int ascending_descending_func_int(int x) {
+    return -(x - 2) * (x - 2);
+}
+
+int descending_ascending_func_int(int x) {
+    return (x - 5) * (x - 5) * (x - 5) * (x - 5);
+}
+
+float ascending_descending_func_float(float x) {
+    return -(x - 9.0f) * (x - 9.0f);
+}
+
+float descending_ascending_func_float(float x) {
+    return (x - 0.5f) * (x - 0.5f) * (x - 0.5f) * (x - 0.5f);
+}
+
 TEST_CASE("Base cases", "[searching][ternary_search]") {
     REQUIRE(ternary_search(vector<int>({5}),  ASCEND_THEN_DESCEND) == 0);
     REQUIRE(ternary_search(vector<int>({5}),  DESCEND_THEN_ASCEND) == 0);
@@ -68,6 +86,26 @@ TEST_CASE("Base cases", "[searching][ternary_search]") {
 
     REQUIRE(ternary_search(vector<int>({4, 5}), ASCEND_THEN_DESCEND) == 1);
     REQUIRE(ternary_search(vector<int>({4, 5}), DESCEND_THEN_ASCEND) == 0);
+
+    REQUIRE(ternary_search(&ascending_descending_func_int, 2, 2, ASCEND_THEN_DESCEND) == 2);
+    REQUIRE(ternary_search(&ascending_descending_func_int, 2, 3, ASCEND_THEN_DESCEND) == 2);
+    REQUIRE(ternary_search([](int x){return -(x - 2) * (x - 2);}, 1, 2, ASCEND_THEN_DESCEND) == 2);
+    REQUIRE(ternary_search([](int x){return -(x - 2) * (x - 2);}, -4, -3, ASCEND_THEN_DESCEND) == -3);
+
+    REQUIRE(ternary_search(&descending_ascending_func_int, 5, 5, DESCEND_THEN_ASCEND) == 5);
+    REQUIRE(ternary_search(&descending_ascending_func_int, 5, 6, DESCEND_THEN_ASCEND) == 5);
+    REQUIRE(ternary_search([](int x){return (x - 5) * (x - 5) * (x - 5) * (x - 5);}, 4, 5, DESCEND_THEN_ASCEND) == 5);
+    REQUIRE(ternary_search([](int x){return (x - 5) * (x - 5) * (x - 5) * (x - 5);}, 12, 13, DESCEND_THEN_ASCEND) == 12);
+
+    REQUIRE(ternary_search(&ascending_descending_func_float, 9.0, 9.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(9.0));
+    REQUIRE(ternary_search(&ascending_descending_func_float, 8.0, 9.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(9.0));
+    REQUIRE(ternary_search([](float x){return -(x - 9.0f) * (x - 9.0f);}, 9.0, 10.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(9.0));
+    REQUIRE(ternary_search([](float x){return -(x - 9.0f) * (x - 9.0f);}, -4.0, -3.0, ASCEND_THEN_DESCEND, 10e-9) == Approx(-3.0));
+
+    REQUIRE(ternary_search(&descending_ascending_func_float, 0.5, 0.5, DESCEND_THEN_ASCEND, 10e-9) == Approx(0.5));
+    REQUIRE(ternary_search(&descending_ascending_func_float, 0.4, 0.5, DESCEND_THEN_ASCEND, 10e-9) == Approx(0.5));
+    REQUIRE(ternary_search([](float x){return (x - 0.5f) * (x - 0.5f) * (x - 0.5f) * (x - 0.5f);}, 0.5, 0.6, DESCEND_THEN_ASCEND, 10e-9) == Approx(0.5));
+    REQUIRE(ternary_search([](float x){return (x - 0.5f) * (x - 0.5f) * (x - 0.5f) * (x - 0.5f);}, 2.2, 2.3, DESCEND_THEN_ASCEND, 10e-9) == Approx(2.2));
 }
 
 TEST_CASE("Normal cases", "[searching][ternary_search]") {
@@ -75,12 +113,21 @@ TEST_CASE("Normal cases", "[searching][ternary_search]") {
     Pattern pattern;
     size_t expected_index;
     for (int test = 0; test < 20; test++) {
-        if (bool(nextRand24() % 2))
+        if (bool(nextRand24() % 2)) {
             pattern = DESCEND_THEN_ASCEND;
-        else
+        }
+        else {
             pattern = ASCEND_THEN_DESCEND;
+        }
         values = nextRandUnimodal(nextRand24() % 1000, pattern);
         expected_index = get_expected_index(values, pattern);
         REQUIRE(ternary_search(values, pattern) == expected_index);
     }
+
+    REQUIRE(ternary_search([](int x){return -(x - 150) * (x - 150);}, 0, 400, ASCEND_THEN_DESCEND) == 150);
+    REQUIRE(ternary_search([](float x){return (x + 351) * (x + 351);}, -1250, 5689, DESCEND_THEN_ASCEND) == -351);
+
+    REQUIRE(ternary_search(&sin, 0.0, M_PI, ASCEND_THEN_DESCEND, 10e-9) == Approx(M_PI_2));
+    REQUIRE(ternary_search(&cos, 0.0, 2.0 * M_PI, DESCEND_THEN_ASCEND, 10e-9) == Approx(M_PI));
+    REQUIRE(ternary_search(&tan, -M_PI/4, M_PI/4, ASCEND_THEN_DESCEND, 10e-9) == Approx(M_PI/4));
 }


### PR DESCRIPTION
<!-- Enter a brief description of the changes you've made in the next line -->
Overloading ternary search to accept a function and an interval as parameters

<!-- Check the following boxes, if applicable, by replacing the space inside
     "[ ]" with an "x", eg. [x] -->

- [x] Read the [contribution guidelines][contrib-guidelines]
- [x] Added [unit tests][unit-tests] (or unit tests have already been added)
- [x] Updated the [Contents][contents]


<!-- If this PR closes an existing issue, write "Closes #261" in the next line,
     where 123 is the issue number (for example) -->
Closes #261


[contrib-guidelines]: https://github.com/faheel/Algos/blob/master/CONTRIBUTING.md
[unit-tests]: https://github.com/faheel/Algos/blob/master/C%2B%2B/UNIT_TESTS.md
[contents]: https://github.com/faheel/Algos/tree/master/C%2B%2B#contents