### PR TITLE
Update documentation and links to ProAlgos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    # Clone your fork of the repo into the current directory
    git clone https://github.com/<your-username>/ProAlgos-Cpp.git
    # Navigate to the newly cloned directory
-   cd Algos
+   cd ProAlgos-Cpp
    # Assign the original repo to a remote called "upstream"
    git remote add upstream https://github.com/ProAlgos/ProAlgos-Cpp.git
    ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@
 
 
 
-[contrib-guidelines]: https://github.com/faheel/Algos/blob/master/CONTRIBUTING.md
-[unit-tests]: https://github.com/faheel/Algos/blob/master/C%2B%2B/UNIT_TESTS.md
-[contents]: https://github.com/faheel/Algos/tree/master/C%2B%2B#contents
+[contrib-guidelines]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/.github/CONTRIBUTING.md
+[unit-tests]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/C++/CONTRIBUTING.md#unit-tests
+[contents]: https://github.com/ProAlgos/ProAlgos-Cpp/tree/master/C%2B%2B#contents

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(Algos)
+project(ProAlgos-Cpp)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/C++/CONTRIBUTING.md
+++ b/C++/CONTRIBUTING.md
@@ -66,4 +66,4 @@ only a specific test and see its results, run it manually from the `bin` directo
 [contrib-guide]: .github/CONTRIBUTING.md
 [catch]: https://github.com/catchorg/Catch2
 [catch-tutorial]: https://github.com/catchorg/Catch2/blob/master/docs/tutorial.md#writing-tests
-[unit-tests]: https://github.com/faheel/Algos/tree/master/C%2B%2B/test
+[unit-tests]: https://github.com/ProAlgos/ProAlgos-Cpp/tree/master/C%2B%2B/test

--- a/C++/README.md
+++ b/C++/README.md
@@ -100,5 +100,5 @@ If you want to contribute an algorithm or data structure in C++, please have a l
 Following the guidelines laid out in these documents will ensure that your code conforms to the standards and style 
 of the project.
 
-[travis-shield]: https://img.shields.io/travis/faheel/Algos.svg?style=for-the-badge
-[travis-link]: https://travis-ci.org/faheel/Algos
+[travis-shield]: https://img.shields.io/travis/ProAlgos/ProAlgos-Cpp.svg?style=for-the-badge
+[travis-link]: https://travis-ci.org/ProAlgos/ProAlgos-Cpp

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ guidelines][contrib-guide], so be sure to check them out.
 
 #### Just want to suggest a new algorithm or report a bug? 
 
-[Create a new issue](https://github.com/faheel/Algos/issues/new) and we'll
+[Create a new issue](https://github.com/ProAlgos/ProAlgos-Cpp/issues/new) and we'll
 handle it from there. :smile:
 
 ## Maintainers
@@ -41,4 +41,4 @@ This project is licensed under the terms of the [MIT license](LICENSE.md).
 [travis-shield]: https://img.shields.io/travis/ProAlgos/ProAlgos-Cpp.svg?style=for-the-badge
 [travis-link]: https://travis-ci.org/ProAlgos/ProAlgos-Cpp
 [contrib-guide]: .github/CONTRIBUTING.md
-[up-for-grabs]: https://github.com/faheel/Algos/labels/Up%20for%20grabs
+[up-for-grabs]: https://github.com/ProAlgos/ProAlgos-Cpp/labels/Up%20for%20grabs


### PR DESCRIPTION
In service of migration from Faheel/Algos to ProAlgos as an organization, updated documentation and links. Also fixed several broken links which hadn't been changed during previous refactorings.