### PR TITLE
Fix return type of linear search algo 

### DIFF
--- a/C++/include/algorithm/searching/linear_search.hpp
+++ b/C++/include/algorithm/searching/linear_search.hpp
@@ -22,16 +22,17 @@
     linear_search
     -------------
     Returns the index where a given element is found in an array. If the
-    element is not found, it returns -1.
+    element is not found, it returns index of element one past last one.
+    same as c++ iterator end style.
 */
 
 template <typename T>
-int linear_search(const T& element, const std::vector<T>& values) {
+size_t linear_search(const T& element, const std::vector<T>& values) {
     for (size_t i = 0; i < values.size(); i++)
         if (values[i] == element)   // it's a match!
             return i;       // return the index at which it was found
 
-    return -1;  // no match is found
+    return values.size();  // no match is found
 }
 
 #endif // LINEAR_SEARCH_HPP

--- a/C++/test/algorithm/searching/linear_search.cpp
+++ b/C++/test/algorithm/searching/linear_search.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Integer cases", "[searching][linear_search]") {
     REQUIRE(linear_search(-15, vector<int>({9, -15, 0, 3, 5})) == 1);
     REQUIRE(linear_search(0, vector<int>({1, 29, 6, 8, 5, 2, 0})) == 6);
     REQUIRE(linear_search(-0, vector<int>({0, -5, 25, 8, 5, 2, 6, 3})) == 0);
-    REQUIRE(linear_search(0, vector<int>({1, 29, 6, 8, 5, 2})) == 7);
+    REQUIRE(linear_search(0, vector<int>({1, 29, 6, 8, 5, 2})) == 6);
 }
 
 

--- a/C++/test/algorithm/searching/linear_search.cpp
+++ b/C++/test/algorithm/searching/linear_search.cpp
@@ -5,9 +5,9 @@ using std::vector;
 using std::string;
 
 TEST_CASE("Base cases", "[searching][linear_search]") {
-    REQUIRE(linear_search(0, vector<int>()) == -1);
+    REQUIRE(linear_search(0, vector<int>()) == 0);
     REQUIRE(linear_search(1, vector<int>({1})) == 0);
-    REQUIRE(linear_search(5, vector<int>({0})) == -1);
+    REQUIRE(linear_search(5, vector<int>({0})) == 1);
 }
 
 TEST_CASE("Integer cases", "[searching][linear_search]") {
@@ -15,7 +15,7 @@ TEST_CASE("Integer cases", "[searching][linear_search]") {
     REQUIRE(linear_search(-15, vector<int>({9, -15, 0, 3, 5})) == 1);
     REQUIRE(linear_search(0, vector<int>({1, 29, 6, 8, 5, 2, 0})) == 6);
     REQUIRE(linear_search(-0, vector<int>({0, -5, 25, 8, 5, 2, 6, 3})) == 0);
-    REQUIRE(linear_search(0, vector<int>({1, 29, 6, 8, 5, 2})) == -1);
+    REQUIRE(linear_search(0, vector<int>({1, 29, 6, 8, 5, 2})) == 7);
 }
 
 


### PR DESCRIPTION
linear-search will return index of item inside the vector, hence it must be of type size_t.
in case of not finding return an index that is one past the last element of the vector.
(same semantics as in C++ iterator end)

- [x] Read the [contribution guidelines][contrib-guidelines]
- [x] Added [unit tests][unit-tests] (or unit tests have already been added)
- [ ] Updated the [Contents][contents]
