### PR TITLE
Fix links in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@
 
 
 
-[contrib-guidelines]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/.github/CONTRIBUTING.md
-[unit-tests]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/.github/CONTRIBUTING.md#adding-unit-tests
-[contents]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/.github/README.md#contents
+[contrib-guidelines]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/docs/CONTRIBUTING.md#contribution-guidelines
+[unit-tests]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/docs/CONTRIBUTING.md#testing-code
+[contents]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/README.md#contents


### PR DESCRIPTION
PR template links were broken by reorganization. This PR fixes those links.