### PR TITLE
Fixed typos errors in Fenwick tree comments

### DIFF
--- a/cpp/include/data_structure/tree/README.md
+++ b/cpp/include/data_structure/tree/README.md
@@ -17,15 +17,14 @@ vector<int> original_array{10, 3, 15, 12, 5};
 
 FenwickTree tree(original_array);
 
-\\ calculate the sum from index 0 -> 2
+// calculate the sum from index 0 -> 2
 tree.calculate_prefix_sum(2)
 
-\\ add 3 to the value located at index = 2
-tree.update_tree(3, 2)
+// add 3 to the value located at index = 2
+tree.update_tree(3, 2);
 
-\\ add -3 to the value located at index = 2
-tree.update_tree(-3, 2)
-
+// add -3 to the value located at index = 2
+tree.update_tree(-3, 2);
 ```
 
 ### Complexity


### PR DESCRIPTION
<!-- Enter a brief description of the changes you've made in the next line -->


<!-- Check the following boxes, if applicable, by replacing the space inside
     "[ ]" with an "x", eg. [x] -->

- [x] Read the [contribution guidelines][contrib-guidelines]
- [ ] Added [unit tests][unit-tests] (or unit tests have already been added)
- [ ] Updated the [Contents][contents]


<!-- If this PR closes an existing issue, write "Closes #123" in the next line,
     where 123 is the issue number (for example) -->



[contrib-guidelines]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/docs/CONTRIBUTING.md#contribution-guidelines
[unit-tests]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/docs/CONTRIBUTING.md#testing-code
[contents]: https://github.com/ProAlgos/ProAlgos-Cpp/blob/master/README.md#contents
